### PR TITLE
Add returned address when TTL is expired.

### DIFF
--- a/src/liboping.c
+++ b/src/liboping.c
@@ -271,7 +271,7 @@ static uint16_t ping_icmp4_checksum (char *buf, size_t len)
 }
 
 static pinghost_t *ping_receive_ipv4 (pingobj_t *obj, char *buffer,
-		size_t buffer_len)
+		size_t buffer_len, int fd)
 {
 	struct ip *ip_hdr;
 	struct icmp *icmp_hdr;
@@ -305,22 +305,10 @@ static pinghost_t *ping_receive_ipv4 (pingobj_t *obj, char *buffer,
 	buffer     += sizeof (struct icmp);
 	buffer_len -= sizeof (struct icmp);
 
-	if (icmp_hdr->icmp_type != ICMP_ECHOREPLY)
+	if (icmp_hdr->icmp_type != ICMP_ECHOREPLY
+		&& icmp_hdr->icmp_type != ICMP_TIMXCEED)
 	{
 		dprintf ("Unexpected ICMP type: %i\n", icmp_hdr->icmp_type);
-		return (NULL);
-	}
-
-	recv_checksum = icmp_hdr->icmp_cksum;
-	icmp_hdr->icmp_cksum = 0;
-	calc_checksum = ping_icmp4_checksum ((char *) icmp_hdr,
-			sizeof (struct icmp) + buffer_len);
-
-	if (recv_checksum != calc_checksum)
-	{
-		dprintf ("Checksum missmatch: Got 0x%04"PRIx16", "
-				"calculated 0x%04"PRIx16"\n",
-				recv_checksum, calc_checksum);
 		return (NULL);
 	}
 
@@ -340,11 +328,19 @@ static pinghost_t *ping_receive_ipv4 (pingobj_t *obj, char *buffer,
 		if (!timerisset (ptr->timer))
 			continue;
 
-		if (ptr->ident != ident)
-			continue;
+		if (icmp_hdr->icmp_type == ICMP_TIMXCEED)
+		{
+			if (ptr->fd != fd)
+				continue;
+		}
+		else
+		{
+			if (ptr->ident != ident)
+				continue;
 
-		if (((ptr->sequence - 1) & 0xFFFF) != seq)
-			continue;
+			if (((ptr->sequence - 1) & 0xFFFF) != seq)
+				continue;
+		}
 
 		dprintf ("Match found: hostname = %s, ident = 0x%04"PRIx16", "
 				"seq = %"PRIu16"\n",
@@ -362,6 +358,22 @@ static pinghost_t *ping_receive_ipv4 (pingobj_t *obj, char *buffer,
 	if (ptr != NULL){
 		ptr->recv_ttl = (int)     ip_hdr->ip_ttl;
 		ptr->recv_qos = (uint8_t) ip_hdr->ip_tos;
+	}
+
+	if (icmp_hdr->icmp_type == ICMP_TIMXCEED)
+		return (ptr);
+
+	recv_checksum = icmp_hdr->icmp_cksum;
+	icmp_hdr->icmp_cksum = 0;
+	calc_checksum = ping_icmp4_checksum ((char *) icmp_hdr,
+			sizeof (struct icmp) + buffer_len);
+
+	if (recv_checksum != calc_checksum)
+	{
+		dprintf ("Checksum missmatch: Got 0x%04"PRIx16", "
+				"calculated 0x%04"PRIx16"\n",
+				recv_checksum, calc_checksum);
+		return (NULL);
 	}
 	return (ptr);
 }
@@ -461,6 +473,9 @@ static int ping_receive_one (pingobj_t *obj, const pinghost_t *ph,
 	pinghost_t *host = NULL;
 	int recv_ttl;
 	uint8_t recv_qos;
+
+	struct sockaddr_storage sin;
+	memset(&sin,0,sizeof(sin));
 	
 	/*
 	 * Set up the receive buffer..
@@ -478,8 +493,8 @@ static int ping_receive_one (pingobj_t *obj, const pinghost_t *ph,
 
 	memset (&msghdr, 0, sizeof (msghdr));
 	/* unspecified source address */
-	msghdr.msg_name = NULL;
-	msghdr.msg_namelen = 0;
+	msghdr.msg_name = &sin;
+	msghdr.msg_namelen = sizeof(sin);
 	/* output buffer vector, see readv(2) */
 	msghdr.msg_iov = &payload_iovec;
 	msghdr.msg_iovlen = 1;
@@ -594,7 +609,7 @@ static int ping_receive_one (pingobj_t *obj, const pinghost_t *ph,
 
 	if (ph->addrfamily == AF_INET)
 	{
-		host = ping_receive_ipv4 (obj, payload_buffer, payload_buffer_len);
+		host = ping_receive_ipv4 (obj, payload_buffer, payload_buffer_len, ph->fd);
 		if (host == NULL)
 			return (-1);
 	}
@@ -628,12 +643,19 @@ static int ping_receive_one (pingobj_t *obj, const pinghost_t *ph,
 			(int) diff.tv_sec,
 			(int) diff.tv_usec);
 
-	if (recv_ttl >= 0)
+	if (recv_ttl <= 0)
+	{
+		memcpy (host->addr, &sin, sizeof(sin));
+		host->addrlen = sizeof(sin);
+	}
+	else
+	{
 		host->recv_ttl = recv_ttl;
-	host->recv_qos = recv_qos;
+		host->recv_qos = recv_qos;
 
-	host->latency  = ((double) diff.tv_usec) / 1000.0;
-	host->latency += ((double) diff.tv_sec)  * 1000.0;
+		host->latency  = ((double) diff.tv_usec) / 1000.0;
+		host->latency += ((double) diff.tv_sec)  * 1000.0;
+	}
 
 	timerclear (host->timer);
 

--- a/src/oping.c
+++ b/src/oping.c
@@ -1569,12 +1569,13 @@ static void update_host_hook (pingobj_iter_t *iter, /* {{{ */
 	}
 	else /* if (!(latency > 0.0)) */
 	{
+		size_t buffer_size = sizeof (context->addr);
+		ping_iterator_get_info (iter, PING_INFO_ADDRESS, context->addr, &buffer_size);
 #if USE_NCURSES
 		if (has_colors () == TRUE)
 		{
-			HOST_PRINTF ("echo reply from %s (%s): icmp_seq=%u ",
-					context->host, context->addr,
-					sequence);
+			HOST_PRINTF ("echo reply from %s: icmp_seq=%u ",
+					context->addr, sequence);
 			wattron (main_win, COLOR_PAIR(OPING_RED) | A_BOLD);
 			HOST_PRINTF ("timeout");
 			wattroff (main_win, COLOR_PAIR(OPING_RED) | A_BOLD);
@@ -1583,9 +1584,8 @@ static void update_host_hook (pingobj_iter_t *iter, /* {{{ */
 		else
 		{
 #endif
-		HOST_PRINTF ("echo reply from %s (%s): icmp_seq=%u timeout\n",
-				context->host, context->addr,
-				sequence);
+		HOST_PRINTF ("echo reply from %s: icmp_seq=%u timeout\n",
+				context->addr, sequence);
 #if USE_NCURSES
 		}
 #endif


### PR DESCRIPTION
This is the suggestion and it has some issues.

### Overview
The current implementation does not handle the returned address ( which is the address of a last router) when TTL is expired. This changes add returned address to a host object when receiving a message and display the returned address as following:
```
$ oping -t 3 www.google.com
PING www.google.com (173.194.126.212) 56 bytes of data.
echo reply from 119.235.224.98: icmp_seq=1 timeout
echo reply from 119.235.224.98: icmp_seq=2 timeout
echo reply from 119.235.224.98: icmp_seq=3 timeout
```

### Good point
There are two good points:

1. It is more informative.
1. It can be used for traceroute.

The followings are the result of current implementation.
 ```
$ oping -t 3 www.google.com
PING www.google.com (216.58.220.196) 56 bytes of data.
echo reply from www.google.com (216.58.220.196): icmp_seq=1 timeout
echo reply from www.google.com (216.58.220.196): icmp_seq=2 timeout
echo reply from www.google.com (216.58.220.196): icmp_seq=3 timeout
```

### Problem
There are two problems:

1. It assume sockid is unique.
1. It supports only IPv4.

About the first problem, it can't assign a received message to the host object correctly If sockfd is not unique. However, if I understand ```socket``` system call correctly, it always returns a unique file descriptor (sockfd) except for the error case and sockfd (which is stored in pinghost) is not reused in liboping.c to establish a connection. So I think sockfd is always unique and it can assign the received message to the correct host object using sockfd.
About the second problem, If this suggestion is accepted, I will implement the code for IPv6.