### PR TITLE
configure: also check for clockgettime()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,12 +199,10 @@ fi
 
 AC_SUBST(LIBOPING_PC_LIBS_PRIVATE)
 
-nanosleep_needs_rt="no"
-AC_CHECK_FUNCS(nanosleep, [],
-	AC_CHECK_LIB(rt, nanosleep,
-		[nanosleep_needs_rt="yes"],
-		AC_MSG_ERROR(cannot find nanosleep)))
-AM_CONDITIONAL(BUILD_WITH_LIBRT, test "x$nanosleep_needs_rt" = "xyes")
+AC_SEARCH_LIBS([nanosleep],[rt],[],
+		[AC_MSG_ERROR([cannot find nanosleep])])
+AC_SEARCH_LIBS([clock_gettime],[rt],[],
+		[AC_MSG_ERROR([cannot find clock_gettime])])
 
 with_ncurses="no"
 AC_CHECK_HEADERS(ncursesw/ncurses.h ncurses.h, [with_ncurses="yes"], [])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,9 +35,6 @@ bin_PROGRAMS = oping
 
 oping_SOURCES = oping.c
 oping_LDADD = liboping.la -lm
-if BUILD_WITH_LIBRT
-oping_LDADD += -lrt
-endif
 
 if BUILD_WITH_LIBNCURSES
 bin_PROGRAMS += noping
@@ -45,9 +42,6 @@ bin_PROGRAMS += noping
 noping_SOURCES = oping.c
 noping_CPPFLAGS = $(AM_CPPFLAGS) -DUSE_NCURSES=1
 noping_LDADD = liboping.la -lm $(NCURSES_LIB)
-if BUILD_WITH_LIBRT
-noping_LDADD += -lrt
-endif
 endif # BUILD_WITH_LIBNCURSES
 
 install-exec-hook:


### PR DESCRIPTION
clock_gettime() is also in -lrt so we also need to check for it.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>