### PR TITLE
liboping.c: fix format-truncation error

### DIFF
--- a/src/liboping.c
+++ b/src/liboping.c
@@ -1636,10 +1636,10 @@ int ping_host_add (pingobj_t *obj, const char *host)
 		}
 		else
 		{
-			char errmsg[PING_ERRMSG_LEN];
+			char errmsg[PING_ERRMSG_LEN - 13];
 
-			snprintf (errmsg, PING_ERRMSG_LEN, "Unknown `ai_family': %i", ai_ptr->ai_family);
-			errmsg[PING_ERRMSG_LEN - 1] = '\0';
+			snprintf (errmsg, sizeof(errmsg), "Unknown `ai_family': %i", ai_ptr->ai_family);
+			errmsg[sizeof(errmsg) - 1] = '\0';
 
 			dprintf ("%s", errmsg);
 			ping_set_error (obj, "getaddrinfo", errmsg);


### PR DESCRIPTION
liboping.c: In function 'ping_host_add':
liboping.c:207:9: error: '%s' directive output may be truncated writing up to 255 bytes into a region of size 243 [-Werror=format-truncation=]
    "%s: %s", function, message);
         ^~
liboping.c:1644:40:
    ping_set_error (obj, "getaddrinfo", errmsg);
                                        ~~~~~~
liboping.c:206:2: note: 'snprintf' output between 14 and 269 bytes into a destination of size 256
  snprintf (obj->errmsg, sizeof (obj->errmsg),
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    "%s: %s", function, message);

Fixes:
 - http://autobuild.buildroot.org/results/b12d86388b495a96194e0bcbb5c19a4e35cbc53d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>