### PR TITLE
Effective net_raw capability management

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ([2.65])
 AC_INIT([liboping],
-	[1.10.0],
+	[1.10.0.1],
 	[liboping@verplant.org],
 	[],
 	[http://noping.cc/])
@@ -24,7 +24,7 @@ AC_SUBST(LIBOPING_PATCH)
 
 # ABI version
 LIBOPING_CURRENT=3
-LIBOPING_REVISION=0
+LIBOPING_REVISION=1
 LIBOPING_AGE=3
 AC_SUBST(LIBOPING_CURRENT)
 AC_SUBST(LIBOPING_REVISION)
@@ -62,7 +62,7 @@ AC_SUBST([pkgconfigdir])
 # Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_TIME
-AC_CHECK_HEADERS([math.h signal.h fcntl.h inttypes.h netdb.h stdint.h stdlib.h string.h sys/socket.h sys/time.h unistd.h locale.h langinfo.h])
+AC_CHECK_HEADERS([math.h signal.h fcntl.h inttypes.h netdb.h stdint.h stdlib.h string.h sys/socket.h sys/time.h unistd.h locale.h langinfo.h sys/capability.h])
 
 # This sucks, but what can I do..?
 AC_CHECK_HEADERS(netinet/in_systm.h, [], [],
@@ -239,6 +239,20 @@ AC_ARG_ENABLE(debug, [AS_HELP_STRING([--enable-debug], [Enable extensive debuggi
 ], [])
 AM_CONDITIONAL(BUILD_WITH_DEBUG, test "x$enable_debug" = "xyes")
 
+AC_ARG_ENABLE(effective-cap,
+        [  --enable-effective-cap enable effective capabilities management (default is yes) ],
+        [case "${enableval}" in
+         yes) enable_effective_cap="yes";;
+          no) enable_effective_cap="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-effective-cap) ;;
+         esac],
+        [enable_effective_cap="yes"]
+)
+if test "$enable_effective_cap" = "yes"; then
+        AC_DEFINE(_EFFECTIVE_CAPABILITIES_MANAGEMENT_, 1, [Defined if the effective capabilities management is enabled.])               
+fi
+
+
 AC_ARG_WITH(perl-bindings, [AS_HELP_STRING([--with-perl-bindings@<:@=OPTIONS@:>@], [Options passed to "perl Makefile.PL".])],
 [
 	if test "x$withval" != "xno" && test "x$withval" != "xyes"
@@ -267,9 +281,12 @@ AC_SUBST(PERL_BINDINGS_OPTIONS)
 AC_SUBST(BINDINGS)
 
 # Checks for library functions.
+AC_C_INLINE
 AC_FUNC_MALLOC
 AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS([gettimeofday memset modf select socket sqrt strcasecmp strdup strerror strncasecmp strtoul])
+AC_FUNC_STRTOD
+AC_CHECK_FUNCS([gettimeofday memset modf select socket sqrt strcasecmp strdup strerror strncasecmp strtoul nl_langinfo setlocale strtol])
+
 
 AC_CONFIG_FILES([Makefile src/Makefile src/liboping.pc src/mans/Makefile bindings/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,9 @@ lib_LTLIBRARIES = liboping.la
 liboping_la_SOURCES = oping.h liboping.c
 
 liboping_la_CPPFLAGS = $(AM_CPPFLAGS)
+liboping_la_CPPFLAGS += `pkg-config --cflags libcap`
 liboping_la_LDFLAGS = $(AM_LDFLAGS) -version-info @LIBOPING_CURRENT@:@LIBOPING_REVISION@:@LIBOPING_AGE@
+liboping_la_LDFLAGS += `pkg-config --libs libcap`
 liboping_la_LIBADD = $(LIBOPING_PC_LIBS_PRIVATE)
 
 pkgconfig_DATA = liboping.pc

--- a/src/liboping.c
+++ b/src/liboping.c
@@ -1344,41 +1344,10 @@ int ping_send (pingobj_t *obj)
 	struct timeval nowtime;
 	struct timeval timeout;
 
-	_Bool need_ipv4_socket = 0;
-	_Bool need_ipv6_socket = 0;
-
 	for (ptr = obj->head; ptr != NULL; ptr = ptr->next)
 	{
 		ptr->latency  = -1.0;
 		ptr->recv_ttl = -1;
-
-		if (ptr->addrfamily == AF_INET)
-			need_ipv4_socket = 1;
-		else if (ptr->addrfamily == AF_INET6)
-			need_ipv6_socket = 1;
-	}
-
-	if (!need_ipv4_socket && !need_ipv6_socket)
-	{
-		ping_set_error (obj, "ping_send", "No hosts to ping");
-		return (-1);
-	}
-
-	if (need_ipv4_socket && obj->fd4 == -1)
-	{
-		obj->fd4 = ping_open_socket(obj, AF_INET);
-		if (obj->fd4 == -1)
-			return (-1);
-		ping_set_ttl (obj, obj->ttl);
-		ping_set_qos (obj, obj->qos);
-	}
-	if (need_ipv6_socket && obj->fd6 == -1)
-	{
-		obj->fd6 = ping_open_socket(obj, AF_INET6);
-		if (obj->fd6 == -1)
-			return (-1);
-		ping_set_ttl (obj, obj->ttl);
-		ping_set_qos (obj, obj->qos);
 	}
 
 	if (gettimeofday (&nowtime, NULL) == -1)
@@ -1701,6 +1670,22 @@ int ping_host_add (pingobj_t *obj, const char *host)
 	ph->table_next = obj->table[ph->ident % PING_TABLE_LEN];
 	obj->table[ph->ident % PING_TABLE_LEN] = ph;
 
+	if (ph->addrfamily == AF_INET && obj->fd4 == -1)
+	{
+		obj->fd4 = ping_open_socket(obj, AF_INET);
+		if (obj->fd4 == -1)
+			return (-1);
+		ping_set_ttl (obj, obj->ttl);
+		ping_set_qos (obj, obj->qos);
+	}
+	if (ph->addrfamily == AF_INET6 && obj->fd6 == -1)
+	{
+		obj->fd6 = ping_open_socket(obj, AF_INET6);
+		if (obj->fd6 == -1)
+			return (-1);
+		ping_set_ttl (obj, obj->ttl);
+		ping_set_qos (obj, obj->qos);
+	}
 	return (0);
 } /* int ping_host_add */
 


### PR DESCRIPTION
Hello,
This version is able to manage the cap_net_raw capability, to set it effective to create the raw socket then clear it. 
This allows to set only permitted cap_net_raw capability without set it effective all the time the program is running ( setcap cap_net_raw=p instead of setcap cap_net_raw=ep).
Best regards,
Olivier