### PR TITLE
Handle BSD specific error case (EHOSTDOWN) in ping_sendto()

### DIFF
--- a/src/liboping.c
+++ b/src/liboping.c
@@ -668,6 +668,11 @@ static ssize_t ping_sendto (pingobj_t *obj, pinghost_t *ph,
 		if (errno == ENETUNREACH)
 			return (0);
 #endif
+		/* BSDs return EHOSTDOWN on ARP/ND failure */
+#if defined(EHOSTDOWN)
+		if (errno == EHOSTDOWN)
+			return (0);
+#endif
 		ping_set_errno (obj, errno);
 	}
 


### PR DESCRIPTION
On IPv4 ARP or IPv6 ND failure, BSDs return EHOSTDOWN as error
code on sendto().  This was not currently handled as "it is not
something we truly care about" - add EHOSTDOWN to the existing cases,
EHOSTUNREACH and ENETUNREACH.

Signed-off-by: Gert Doering <gert@greenie.muc.de>