### PR TITLE
Multiping!

### DIFF
--- a/src/liboping.c
+++ b/src/liboping.c
@@ -1550,13 +1550,23 @@ static pinghost_t *ping_host_search (pinghost_t *ph, const char *host)
 	return (ph);
 }
 
+/* wrapper around ping_host_add_multi() to preserve existing
+ * calling / return convention
+ */
 int ping_host_add (pingobj_t *obj, const char *host)
+{
+	int n = ping_host_add_multi( obj, host, 1 );
+	return n < 0 ? n: 0;
+}
+
+int ping_host_add_multi (pingobj_t *obj, const char *host, int max_hosts)
 {
 	pinghost_t *ph;
 
 	struct addrinfo  ai_hints;
 	struct addrinfo *ai_list, *ai_ptr;
 	int              ai_return;
+	int		 hosts_added = 0;
 
 	if ((obj == NULL) || (host == NULL))
 		return (-1);
@@ -1577,37 +1587,6 @@ int ping_host_add (pingobj_t *obj, const char *host)
 	ai_hints.ai_family    = obj->addrfamily;
 	ai_hints.ai_socktype  = SOCK_RAW;
 
-	if ((ph = ping_alloc ()) == NULL)
-	{
-		dprintf ("Out of memory!\n");
-		return (-1);
-	}
-
-	if ((ph->username = strdup (host)) == NULL)
-	{
-		dprintf ("Out of memory!\n");
-		ping_set_errno (obj, errno);
-		ping_free (ph);
-		return (-1);
-	}
-
-	if ((ph->hostname = strdup (host)) == NULL)
-	{
-		dprintf ("Out of memory!\n");
-		ping_set_errno (obj, errno);
-		ping_free (ph);
-		return (-1);
-	}
-
-	/* obj->data is not garuanteed to be != NULL */
-	if ((ph->data = strdup (obj->data == NULL ? PING_DEF_DATA : obj->data)) == NULL)
-	{
-		dprintf ("Out of memory!\n");
-		ping_set_errno (obj, errno);
-		ping_free (ph);
-		return (-1);
-	}
-
 	if ((ai_return = getaddrinfo (host, NULL, &ai_hints, &ai_list)) != 0)
 	{
 #if defined(EAI_SYSTEM)
@@ -1620,7 +1599,6 @@ int ping_host_add (pingobj_t *obj, const char *host)
 						? sstrerror (errno, errbuf, sizeof (errbuf)) :
 #endif
 				gai_strerror (ai_return));
-		ping_free (ph);
 		return (-1);
 	}
 
@@ -1629,6 +1607,29 @@ int ping_host_add (pingobj_t *obj, const char *host)
 
 	for (ai_ptr = ai_list; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next)
 	{
+		if ((ph = ping_alloc ()) == NULL)
+		{
+			dprintf ("Out of memory!\n");
+			return (-1);
+		}
+
+		if ((ph->username = strdup (host)) == NULL)
+		{
+			dprintf ("Out of memory!\n");
+			ping_set_errno (obj, errno);
+			ping_free (ph);
+			return (-1);
+		}
+
+		/* obj->data is not garuanteed to be != NULL */
+		if ((ph->data = strdup (obj->data == NULL ? PING_DEF_DATA : obj->data)) == NULL)
+		{
+			dprintf ("Out of memory!\n");
+			ping_set_errno (obj, errno);
+			ping_free (ph);
+			return (-1);
+		}
+
 		if (ai_ptr->ai_family == AF_INET)
 		{
 			ai_ptr->ai_socktype = SOCK_RAW;
@@ -1648,7 +1649,16 @@ int ping_host_add (pingobj_t *obj, const char *host)
 
 			dprintf ("%s", errmsg);
 			ping_set_error (obj, "getaddrinfo", errmsg);
+			ping_free (ph);
 			continue;
+		}
+
+		if ((ph->hostname = strdup (host)) == NULL)
+		{
+			dprintf ("Out of memory!\n");
+			ping_set_errno (obj, errno);
+			ping_free (ph);
+			return (-1);
 		}
 
 		assert (sizeof (struct sockaddr_storage) >= ai_ptr->ai_addrlen);
@@ -1678,35 +1688,42 @@ int ping_host_add (pingobj_t *obj, const char *host)
 			}
 		}
 #endif /* AI_CANONNAME */
+
+		/*
+		 * Adding in the front is much easier, but then the iterator will
+		 * return the host that was added last as first host. That's just not
+		 * nice. -octo
+		 */
+		if (obj->head == NULL)
+		{
+			obj->head = ph;
+		}
+		else
+		{
+			pinghost_t *hptr;
+
+			hptr = obj->head;
+			while (hptr->next != NULL)
+				hptr = hptr->next;
+
+			assert ((hptr != NULL) && (hptr->next == NULL));
+			hptr->next = ph;
+		}
+
+		ph->table_next = obj->table[ph->ident % PING_TABLE_LEN];
+		obj->table[ph->ident % PING_TABLE_LEN] = ph;
+		hosts_added++;
+
+		if ( max_hosts > 0 && hosts_added >= max_hosts )
+		{
+			break;
+		}
+
 	} /* for (ai_ptr = ai_list; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next) */
 
 	freeaddrinfo (ai_list);
 
-	/*
-	 * Adding in the front is much easier, but then the iterator will
-	 * return the host that was added last as first host. That's just not
-	 * nice. -octo
-	 */
-	if (obj->head == NULL)
-	{
-		obj->head = ph;
-	}
-	else
-	{
-		pinghost_t *hptr;
-
-		hptr = obj->head;
-		while (hptr->next != NULL)
-			hptr = hptr->next;
-
-		assert ((hptr != NULL) && (hptr->next == NULL));
-		hptr->next = ph;
-	}
-
-	ph->table_next = obj->table[ph->ident % PING_TABLE_LEN];
-	obj->table[ph->ident % PING_TABLE_LEN] = ph;
-
-	return (0);
+	return (hosts_added);
 } /* int ping_host_add */
 
 int ping_host_remove (pingobj_t *obj, const char *host)

--- a/src/mans/ping_host_add.pod
+++ b/src/mans/ping_host_add.pod
@@ -6,8 +6,9 @@ ping_host_add - Add a host to a liboping object
 
   #include <oping.h>
 
-  int ping_host_add    (pingobj_t *obj, const char *host);
-  int ping_host_remove (pingobj_t *obj, const char *host);
+  int ping_host_add       (pingobj_t *obj, const char *host);
+  int ping_host_add_multi (pingobj_t *obj, const char *host, int max_hosts);
+  int ping_host_remove    (pingobj_t *obj, const char *host);
 
 =head1 DESCRIPTION
 
@@ -21,6 +22,13 @@ The I<host> parameter is a '\0' terminated string which is interpreted as a
 hostname or an IP address. Depending on the address family setting, set with
 L<ping_setopt(3)>, the hostname is resolved to an IPv4 or IPv6 address.
 
+If more than one result is returned by DNS, only the first result is used.
+
+The B<ping_host_add_multi> extends the B<ping_host_add> function to
+permit adding up to I<max_hosts> DNS results (IPv4 and IPv6, or multiple
+IPv4 / IPv6 records) to the liboping object.  If I<max_hosts> is 0, there
+is no limit = add all records returned by DNS.
+
 The B<ping_host_remove> method looks for I<host> within I<obj> and remove it if
 found. It will close the socket and deallocate the memory, too.
 
@@ -32,6 +40,10 @@ name can be queried using L<ping_iterator_get_info(3)>.
 If B<ping_host_add> succeeds it returns zero. If an error occurs a value less
 than zero is returned and the last error is saved internally. You can receive
 the error message using L<ping_get_error(3)>.
+
+If B<ping_host_add_multi> succeeds it returns the number of hosts added. If 
+an error occurs a value less than zero is returned and the last error is 
+saved internally. You can receive the error message using L<ping_get_error(3)>.
 
 B<ping_host_remove> returns zero upon success and less than zero if it failed.
 Currently the only reason for failure is that the host isn't found, but this is

--- a/src/oping.c
+++ b/src/oping.c
@@ -220,6 +220,7 @@ static int     opt_utf8       = 0;
 #endif
 static char   *opt_outfile    = NULL;
 static int     opt_bell       = 0;
+static int     opt_max_hosts  = 1;
 
 static int host_num  = 0;
 static FILE *outfile = NULL;
@@ -682,7 +683,7 @@ static int read_options (int argc, char **argv) /* {{{ */
 
 	while (1)
 	{
-		optchar = getopt (argc, argv, "46c:hi:I:t:Q:f:D:Z:O:P:m:w:b"
+		optchar = getopt (argc, argv, "46c:hi:I:t:Q:f:D:Z:O:P:m:w:ba"
 #if USE_NCURSES
 				"uUg:H:"
 #endif
@@ -854,6 +855,10 @@ static int read_options (int argc, char **argv) /* {{{ */
 
 				break;
 			}
+
+			case 'a':
+				opt_max_hosts = -1;	/* all */
+				break;
 
 			case 'h':
 				usage_exit (argv[0], 0);
@@ -1944,7 +1949,8 @@ int main (int argc, char **argv) /* {{{ */
 			if ((host[0] == 0) || (host[0] == '#'))
 				continue;
 
-			if (ping_host_add(ping, host) < 0)
+			int n = ping_host_add_multi(ping, host, opt_max_hosts);
+			if (n < 0)
 			{
 				const char *errmsg = ping_get_error (ping);
 
@@ -1953,7 +1959,7 @@ int main (int argc, char **argv) /* {{{ */
 			}
 			else
 			{
-				host_num++;
+				host_num+=n;
 			}
 		}
 
@@ -1984,7 +1990,8 @@ int main (int argc, char **argv) /* {{{ */
 
 	for (i = optind; i < argc; i++)
 	{
-		if (ping_host_add (ping, argv[i]) < 0)
+		int n = ping_host_add_multi (ping, argv[i], opt_max_hosts);
+		if (n < 0)
 		{
 			const char *errmsg = ping_get_error (ping);
 
@@ -1993,7 +2000,7 @@ int main (int argc, char **argv) /* {{{ */
 		}
 		else
 		{
-			host_num++;
+			host_num+=n;
 		}
 	}
 

--- a/src/oping.h
+++ b/src/oping.h
@@ -71,6 +71,7 @@ int ping_setopt (pingobj_t *obj, int option, void *value);
 int ping_send (pingobj_t *obj);
 
 int ping_host_add (pingobj_t *obj, const char *host);
+int ping_host_add_multi (pingobj_t *obj, const char *host, int max_hosts);
 int ping_host_remove (pingobj_t *obj, const char *host);
 
 pingobj_iter_t *ping_iterator_get (pingobj_t *obj);


### PR DESCRIPTION
Here's the PR as discussed in issue #52 

I have rewritten it to add "-a", keep the calling convention for ping_host_add() and update the .pod documentation.

I'm not particularily attached to implementation details - this is a suggested way to implement it, which works for me :-) - but I can rewrite it (options, names, functions, ...) to better suit the project style.

If it were my decision, I would make "-a" the default, because that is what *I* use - "ping that thing, with whatever you have, all of it!".  So there could be an option, like "-1", to turn it off and return to "only the first hit is pinged".  But this is really fine tuning.  Having the default "behaviour as before" with an extra "-a" to get "all targets" also works for me (and there's good arguments for not changing user visible behaviour).

As to the patch itself: there is two commits in the branch, one is the "multiping" functionality.  The second one is something I find useful: if I have two hosts "heise.de" in the noping output, it's not easy to see whether v4 or or v6 ping is failing, so I modify the hostname in the liboping obj and attach a "/v4" or "/v6" to it, so it is more easily seen.  This is totally independent, and the multiping change does not need it.