### PR TITLE
Fix HOST_PRINTF format string

### DIFF
--- a/src/oping.c
+++ b/src/oping.c
@@ -1639,8 +1639,7 @@ static void update_host_hook (pingobj_iter_t *iter, /* {{{ */
 
 			HOST_PRINTF ("%zu bytes from %s (%s): icmp_seq=%u ttl=%i ",
 					data_len, context->host, context->addr,
-					sequence, recv_ttl,
-					format_qos (recv_qos, recv_qos_str, sizeof (recv_qos_str)));
+					sequence, recv_ttl);
 			if ((recv_qos != 0) || (opt_send_qos != 0))
 			{
 				HOST_PRINTF ("qos=%s ",


### PR DESCRIPTION
Without this patch the printf invocation takes more argument that it has format strings, since the format_qos() output string is printed in the if statement following the HOST_PRINTF invocation, I believe this to be an accidental error made in 66464b61f8ee756dcfc0081944f4367da2b1a6ab (this commit removes the format from the format string but doesn't remove the argument).