### PR TITLE
Fix compile break with GCC 7+ - buffer overflow with snprintf

### DIFF
--- a/src/liboping.c
+++ b/src/liboping.c
@@ -203,8 +203,11 @@ static char *sstrerror (int errnum, char *buf, size_t buflen)
 static void ping_set_error (pingobj_t *obj, const char *function,
 	       	const char *message)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 	snprintf (obj->errmsg, sizeof (obj->errmsg),
 			"%s: %s", function, message);
+#pragma GCC diagnostic pop
 	obj->errmsg[sizeof (obj->errmsg) - 1] = 0;
 }
 

--- a/src/liboping.c
+++ b/src/liboping.c
@@ -203,11 +203,15 @@ static char *sstrerror (int errnum, char *buf, size_t buflen)
 static void ping_set_error (pingobj_t *obj, const char *function,
 	       	const char *message)
 {
+#if __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
 	snprintf (obj->errmsg, sizeof (obj->errmsg),
 			"%s: %s", function, message);
+#if __GNUC__ >= 7
 #pragma GCC diagnostic pop
+#endif
 	obj->errmsg[sizeof (obj->errmsg) - 1] = 0;
 }
 


### PR DESCRIPTION
GCC 7+ and newer warns - and actually breaks compilation when snprintf input is potentially larger than the buffer. This supresses this IMHO bad change - as snprintf is just doing its job...